### PR TITLE
fix:  New config provider returns empty array on creation

### DIFF
--- a/src/eclConfigProvider.ts
+++ b/src/eclConfigProvider.ts
@@ -24,10 +24,6 @@ export class ECLConfigurationProvider implements vscode.DebugConfigurationProvid
         return eclConfigurationProvider;
     }
 
-    provideDebugConfigurations?(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
-        return [];
-    }
-
     credentials(debugConfiguration: vscode.DebugConfiguration): Credentials {
         let retVal = this._credentials[debugConfiguration.name];
         if (!retVal) {


### PR DESCRIPTION
Removed method to revert to default (use default config from settings).

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>