### PR TITLE
fix(config): Ubuntu fails to retrieve config setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,6 +344,7 @@
             "properties": {
                 "ecl.syntaxArgs": {
                     "type": "array",
+                    "scope": "resource",
                     "items": {
                         "type": "string"
                     },


### PR DESCRIPTION
Change config "scope" setting to "resource"

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>