### PR TITLE
fix: Invalid hot key mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,11 +151,6 @@
                 "key": "shift+f8",
                 "mac": "shift+f8",
                 "when": "editorTextFocus"
-            },
-            {
-                "command": "ecl.showAllDocumentation",
-                "key": "shift+f12",
-                "mac": "shift+f12"
             }
         ],
         "viewsContainers": {


### PR DESCRIPTION
Remove hot key as it has no associated command.

Fixes GH-121

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>