### PR TITLE
fix(Syntaxes) ECL and KEL syntax colorizers overgeneralizing functions

### DIFF
--- a/syntaxes/ecl.tmLanguage.json
+++ b/syntaxes/ecl.tmLanguage.json
@@ -61,7 +61,6 @@
             "match": "\\b(?i:(std).(file|date|str|math|metaphone|metaphone3|uni|audit|blas|system.(debug|email|job|log|thorlib|util|workunit)))\\b"
         },
         {
-            "name": "entity.name.function.ecl",
             "match": "([A-Za-z_]+)\\s*(\\()",
             "captures": {
                 "1": {

--- a/syntaxes/kel.tmLanguage.json
+++ b/syntaxes/kel.tmLanguage.json
@@ -21,7 +21,6 @@
             "match": "\\b(?i:(%|\\*|\\+|-|/|and|div|in|not|or))\\b"
         },
         {
-            "name": "entity.name.function.kel",
             "match": "([A-Za-z_]+)\\s*(\\()",
             "captures": {
                 "1": {


### PR DESCRIPTION
Signed-off-by: David de Hilster <david.dehilster@lexisnexisrisk.com>