### PR TITLE
fix(results):  Incorrect password passed to result viewer

### DIFF
--- a/src/hpccplatform/launchConfig.ts
+++ b/src/hpccplatform/launchConfig.ts
@@ -202,6 +202,10 @@ export class LaunchConfig implements LaunchRequestArguments {
     }
 
     get password() {
+        const creds = credentials[this.serverAddress];
+        if (creds?.verified) {
+            return creds.password;
+        }
         return config(this._lcID, "password", "");
     }
 


### PR DESCRIPTION
Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>