### PR TITLE
fix: Whitespace in es, pt, and zh localization files

### DIFF
--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -128,7 +128,7 @@
     "Submit ECL to HPCC Platform": "Enviar ECL a la plataforma HPCC",
     "Submits ECL to public demo servers, hthor": "Envía ECL a servidores públicos de demostración, hthor",
     "Submitted workunit": "Unidades de trabajo sormitidos",
-    "Submitting ECL via the Run/Debug page is being deprecated.  Please use the new Submit + Compile buttons at the top of the ECL Editor": "El envío de ECL a través de la página Ejecutar / Depurar está obsoleto. Utilice los nuevos botones Enviar + Compilar en la parte superior del Editor ECL",
+    "Submitting ECL via the Run/Debug page is being deprecated. Please use the new Submit + Compile buttons at the top of the ECL Editor": "El envío de ECL a través de la página Ejecutar / Depurar está obsoleto. Utilice los nuevos botones Enviar + Compilar en la parte superior del Editor ECL",
     "Submitting workunit": "Enviar unidad de trabajo",
     "Switch HPCC Platform": "Cambiar HPCC Platform",
     "Switch Target Cluster": "Cambiar sistemas de destino",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -127,7 +127,7 @@
     "Submit ECL to HPCC Platform": "Submeter ECL para a plataforma HPCC",
     "Submits ECL to public demo servers, hthor": "Submeter ECL para servidores de demonstração públicos, hthor",
     "Submitted workunit": "workunit submetida",
-    "Submitting ECL via the Run/Debug page is being deprecated.  Please use the new Submit + Compile buttons at the top of the ECL Editor": "Submissão de código ECL via opção Run/Debug não é mais suportada. Favor utilizar os novos botões Submit + Compile no canto superior direito da área de edição de código ECL.",
+    "Submitting ECL via the Run/Debug page is being deprecated. Please use the new Submit + Compile buttons at the top of the ECL Editor": "Submissão de código ECL via opção Run/Debug não é mais suportada. Favor utilizar os novos botões Submit + Compile no canto superior direito da área de edição de código ECL.",
     "Submitting workunit": "Submetendo workunit",
     "Switch HPCC Platform": "Mudar plataforma HPCC",
     "Switch Target Cluster": "Mudar cluster de destino",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -128,7 +128,7 @@
     "Submit ECL to HPCC Platform": "提交ECL到HPCC平台",
     "Submits ECL to public demo servers, hthor": "提交ECL到公共演示服务器，hthor",
     "Submitted workunit": "已提交的workunit",
-    "Submitting ECL via the Run/Debug page is being deprecated.  Please use the new Submit + Compile buttons at the top of the ECL Editor": "不建议使用通过Run/Debug网页提交ECL。请用ECL Editor上端新的提交+编译键",
+    "Submitting ECL via the Run/Debug page is being deprecated. Please use the new Submit + Compile buttons at the top of the ECL Editor": "不建议使用通过Run/Debug网页提交ECL。请用ECL Editor上端新的提交+编译键",
     "Submitting workunit": "提交workunit",
     "Switch HPCC Platform": "转换HPCC平台",
     "Switch Target Cluster": "转换目标群",


### PR DESCRIPTION
#398 Fix whitespace in es, pt, and zh localization files for future automation scripts for localization strings.